### PR TITLE
JWT refresh가 완료되기 전까지 컴포넌트들을 렌더링하지 않도록 수정

### DIFF
--- a/src/context/user.tsx
+++ b/src/context/user.tsx
@@ -42,6 +42,12 @@ const UserProvider: React.FC = props => {
 
 	const [user, setUser] = useState<IUser | null>(JSON.parse(localStorage.getItem('user') || 'null'));
 
+	const [initialRefreshDone, setInitialRefreshDone] = useState(false);
+
+	useEffect(() => {
+		refresh.refetch().then(() => setInitialRefreshDone(true));
+	}, []);
+
 	// login (or refresh) and set user data
 	useEffect(() => {
 		if (refresh.data !== undefined) {
@@ -92,7 +98,7 @@ const UserProvider: React.FC = props => {
 				refresh,
 				logout,
 			}}>
-			{children}
+			{initialRefreshDone && children}
 		</UserContext.Provider>
 	);
 };


### PR DESCRIPTION
## Summary
* PR의 주요 목적은 JWT refresh가 완료된 후 컴포넌트 렌더링, REST API 호출이 일어나도록 하는 것임
* `UserContext.Provider`에서 JWT refresh가 완료된 후 자식 컴포넌트가 렌더링되도록 하였음

## Related Issue
* Close #15 