### PR TITLE
ajax 사용 시 `Authorization` 헤더를 제거할 때 소문자 버전인 `authorization` 을 제거하지 않아 발생하는 문제 해결

### DIFF
--- a/src/context/user.tsx
+++ b/src/context/user.tsx
@@ -17,6 +17,7 @@ const UserContext = createContext<{
 const withoutAuthorization = {
 	transformRequest: (data: any, headers: AxiosRequestHeaders | undefined) => {
 		// refresh endpoint only accepts cookie, NOT Authorization header
+		delete (headers as any)?.common['authorization'];
 		delete (headers as any)?.common['Authorization']; // axios type mismatch WTF
 		return data;
 	},


### PR DESCRIPTION
## Summary
* ajax 사용 시 `Authorization` 헤더를 제거할 때 소문자 버전인 `authorization` 을 제거하지 않아 발생하는 문제 해결

## Related Issue
* Close #17 