### PR TITLE
마인크래프트 계정 연동 기능 구현

### DIFF
--- a/src/actions/minecraftAccount.ts
+++ b/src/actions/minecraftAccount.ts
@@ -1,0 +1,23 @@
+import { useMutation, useQuery } from 'react-query';
+
+import { IMinecraftAccount } from '../models/minecraftAccount';
+import { accountsApiClient } from '../services/api';
+
+export { useMinecraftAccountVerifyRead, useMinecraftAccountVerify };
+
+function useMinecraftAccountVerifyRead(code: string | undefined) {
+	return useQuery(
+		['minecraftAccountVerify', code],
+		() => accountsApiClient.get<IMinecraftAccount>(`/minecraft-accounts/verify/${code}`).then(response => response.data),
+		{
+			enabled: typeof code === 'string',
+		},
+	);
+}
+
+function useMinecraftAccountVerify(options?: Parameters<typeof useMutation>[2]) {
+	return useMutation<unknown, unknown, string>(
+		code => accountsApiClient.post(`/minecraft-accounts/verify/${code}`).then(response => response.data),
+		options,
+	);
+}

--- a/src/components/AppRoutes.tsx
+++ b/src/components/AppRoutes.tsx
@@ -4,6 +4,7 @@ import { Route, Routes } from 'react-router';
 import { MtlBaseLayout } from './layouts/MtlBaseLayout';
 import { Index } from './pages/Index';
 import { Login, LoginCallback } from './pages/Login';
+import { MinecraftAccountVerify } from './pages/MinecraftAccountVerify';
 import { MinecraftMap } from './pages/MinecraftMap';
 import { NavBarEdit } from './pages/NavBarEdit';
 import { NoticeAdd } from './pages/NoticeAdd';
@@ -38,6 +39,8 @@ const AppRoutes: React.FC = () => {
 
 				<Route path="navbar" element={<NavBarEdit />} />
 				<Route path="users" element={<Users />} />
+
+				<Route path="minecraft-accounts/verify/:code" element={<MinecraftAccountVerify />} />
 			</Route>
 		</Routes>
 	);

--- a/src/components/pages/Login.tsx
+++ b/src/components/pages/Login.tsx
@@ -1,5 +1,6 @@
 import { Box } from '@mui/material';
 import React, { useEffect } from 'react';
+import { useSearchParams } from 'react-router-dom';
 
 import { useUserRefresh } from '../../actions/user';
 import { MtlDialog, MtlDialogContent, MtlDialogTitle } from '../basics/MtlDialog';
@@ -37,7 +38,14 @@ const openLoginWindow = (url: string, name: string) => {
 	previousUrl = url;
 };
 
+type LoginReason = 'minecraft-account' | null;
+
 const Login: React.FC = () => {
+	const [searchParams, _] = useSearchParams();
+
+	const reason: LoginReason = searchParams.get('reason') as LoginReason;
+	const redirectUrlWhenSuccessLogin = reason === 'minecraft-account' ? `/minecraft-accounts/verify/${searchParams.get('code')}` : '/';
+
 	const onMessage = (e: MessageEvent) => {
 		// Do we trust the sender of this message? (might be
 		// different from what we originally opened, for example).
@@ -49,8 +57,8 @@ const Login: React.FC = () => {
 		if (data?.type === 'oauth2') {
 			// when login success, go to main page
 			if (data?.result === 'success') {
-				console.log('Successfully authenticated, redirect to / ..');
-				window.location.href = '/';
+				console.log(`Successfully authenticated, redirect to ${redirectUrlWhenSuccessLogin} ..`);
+				window.location.href = redirectUrlWhenSuccessLogin;
 			}
 		}
 	};

--- a/src/components/pages/MinecraftAccountVerify.tsx
+++ b/src/components/pages/MinecraftAccountVerify.tsx
@@ -1,0 +1,58 @@
+import { Box, Button, Typography } from '@mui/material';
+import React from 'react';
+import { Navigate, useParams } from 'react-router';
+
+import { useMinecraftAccountVerify, useMinecraftAccountVerifyRead } from '../../actions/minecraftAccount';
+import { useUser } from '../../actions/user';
+import { MtlPageContents } from '../basics/MtlPageContents';
+import { MtlPageTitle } from '../basics/MtlPageTitle';
+import { MtlSpacer } from '../basics/MtlSpacer';
+
+export { MinecraftAccountVerify };
+
+const MinecraftAccountVerify: React.FC = () => {
+	const user = useUser();
+	const { code } = useParams();
+	const { data: minecraftAccount, isError } = useMinecraftAccountVerifyRead(code);
+	const minecraftAccountVerify = useMinecraftAccountVerify();
+
+	if (user === null) return <Navigate to={`/login?reason=minecraft-account&code=${code}`} />;
+
+	return (
+		<MtlPageContents>
+			<MtlPageTitle>마인크래프트 계정 연동</MtlPageTitle>
+
+			{minecraftAccountVerify.isSuccess ? (
+				<>성공적으로 연동하였습니다! 창을 닫고 서버에 재접속해주세요.</>
+			) : code === undefined ? (
+				<>연동을 위한 code가 존재하지 않습니다.</>
+			) : isError ? (
+				<>해당 code는 만료되었거나 존재하지 않습니다.</>
+			) : minecraftAccount === undefined ? (
+				<>로딩중입니다...</>
+			) : (
+				<Box
+					sx={{
+						display: 'flex',
+						flexDirection: 'column',
+					}}>
+					<Typography>
+						{minecraftAccount.display_name} 계정을 연결하려고 합니다. 본인의 계정이 맞다면 아래 확인 버튼을 눌러주세요.
+					</Typography>
+
+					<MtlSpacer vertical={20} />
+
+					<Box
+						sx={{
+							display: 'flex',
+							justifyContent: 'flex-end',
+						}}>
+						<Button variant="contained" onClick={() => minecraftAccountVerify.mutate(code)}>
+							확인
+						</Button>
+					</Box>
+				</Box>
+			)}
+		</MtlPageContents>
+	);
+};

--- a/src/models/minecraftAccount.ts
+++ b/src/models/minecraftAccount.ts
@@ -1,0 +1,7 @@
+export type { IMinecraftAccount };
+
+type IMinecraftAccount = {
+    id: string;
+    provider: 'java' | 'bedrock';
+    display_name: string;
+};


### PR DESCRIPTION
## Summary
* 마인크래프트 연동 기능 구현
* `metaland-netherite` 에서 code를 URL을 통해 Front-end로 주면 해당 code를 `metaland-accounts` 에 전달하여 연동 요청

## Related Issue
* Close #20 